### PR TITLE
Hk file advanced

### DIFF
--- a/src/filesys/file.c
+++ b/src/filesys/file.c
@@ -166,8 +166,3 @@ file_tell (struct file *file)
   ASSERT (file != NULL);
   return file->pos;
 }
-
-bool is_deny(struct file *file){
-  ASSERT (file != NULL);
-  return file->deny_write;
-}

--- a/src/filesys/file.h
+++ b/src/filesys/file.h
@@ -27,7 +27,4 @@ void file_seek (struct file *, off_t);
 off_t file_tell (struct file *);
 off_t file_length (struct file *);
 
-/* Writable*/
-bool is_deny(struct file *);
-
 #endif /* filesys/file.h */

--- a/src/filesys/inode.c
+++ b/src/filesys/inode.c
@@ -6,6 +6,7 @@
 #include "filesys/filesys.h"
 #include "filesys/free-map.h"
 #include "threads/malloc.h"
+#include "threads/synch.h"
 
 /* Identifies an inode. */
 #define INODE_MAGIC 0x494e4f44
@@ -36,6 +37,7 @@ struct inode
     int open_cnt;                       /* Number of openers. */
     bool removed;                       /* True if deleted, false otherwise. */
     int deny_write_cnt;                 /* 0: writes ok, >0: deny writes. */
+    struct lock rw_lock;                /* Guarantree atomic read or write*/
     struct inode_disk data;             /* Inode content. */
   };
 
@@ -137,6 +139,7 @@ inode_open (block_sector_t sector)
   inode->open_cnt = 1;
   inode->deny_write_cnt = 0;
   inode->removed = false;
+  lock_init(&inode->rw_lock);
   block_read (fs_device, inode->sector, &inode->data);
   return inode;
 }
@@ -204,6 +207,7 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
   off_t bytes_read = 0;
   uint8_t *bounce = NULL;
 
+  lock_acquire(&inode->rw_lock);
   while (size > 0) 
     {
       /* Disk sector to read, starting byte offset within sector. */
@@ -245,6 +249,7 @@ inode_read_at (struct inode *inode, void *buffer_, off_t size, off_t offset)
       bytes_read += chunk_size;
     }
   free (bounce);
+  lock_release(&inode->rw_lock);
 
   return bytes_read;
 }
@@ -265,6 +270,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
   if (inode->deny_write_cnt)
     return 0;
 
+  lock_acquire(&inode->rw_lock);
   while (size > 0) 
     {
       /* Sector to write, starting byte offset within sector. */
@@ -313,6 +319,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
       bytes_written += chunk_size;
     }
   free (bounce);
+  lock_release(&inode->rw_lock);
 
   return bytes_written;
 }

--- a/src/lib/syscall-nr.h
+++ b/src/lib/syscall-nr.h
@@ -28,7 +28,10 @@ enum
     SYS_MKDIR,                  /* Create a directory. */
     SYS_READDIR,                /* Reads a directory entry. */
     SYS_ISDIR,                  /* Tests if a fd represents a directory. */
-    SYS_INUMBER                 /* Returns the inode number for a fd. */
+    SYS_INUMBER,                 /* Returns the inode number for a fd. */
+
+    SYS_MALLOC,                /* Malloc user memory. */
+    SYS_FREE                  /* Release user memory. */
   };
 
 #endif /* lib/syscall-nr.h */

--- a/src/lib/user/malloc.c
+++ b/src/lib/user/malloc.c
@@ -1,0 +1,53 @@
+#include <malloc.h>
+#include <string.h>
+#include "../syscall-nr.h"
+
+/* Invokes syscall NUMBER, passing argument ARG0, and returns the
+   return value as an `int'. */
+#define syscall1(NUMBER, ARG0)                                           \
+        ({                                                               \
+          int retval;                                                    \
+          asm volatile                                                   \
+            ("pushl %[arg0]; pushl %[number]; int $0x30; addl $8, %%esp" \
+               : "=a" (retval)                                           \
+               : [number] "i" (NUMBER),                                  \
+                 [arg0] "g" (ARG0)                                       \
+               : "memory");                                              \
+          retval;                                                        \
+        })
+
+void *
+malloc(size_t size)
+{
+    return (void *) syscall1 (SYS_MALLOC, size);
+}
+
+void *
+calloc(size_t a, size_t b)
+{
+  void *p;
+  size_t size;
+
+  /* Calculate block size and make sure it fits in size_t. */
+  size = a * b;
+  if (size < a || size < b)
+    return NULL;
+
+  /* Allocate and zero memory. */
+  p = (void *) syscall1 (SYS_MALLOC, size);
+  if (p != NULL)
+    memset (p, 0, size);
+
+  return p;
+}
+
+void *
+realloc(void * old, size_t size)
+{
+
+}
+
+void free(void *p)
+{
+  syscall1 (SYS_FREE, p);
+}

--- a/src/lib/user/malloc.h
+++ b/src/lib/user/malloc.h
@@ -1,0 +1,11 @@
+#ifndef LIB_USER_MALLOC
+#define LIB_USER_MALLOC
+
+#include <stddef.h>
+
+void *malloc(size_t);
+void *calloc(size_t, size_t);
+void *realloc(void *, size_t);
+void free(void *);
+
+#endif

--- a/src/lib/user/stdsyscall.c
+++ b/src/lib/user/stdsyscall.c
@@ -1,0 +1,37 @@
+#include <stdsyscall.h>
+
+struct FILE{
+    void* rd_buffer;
+    void* wr_buufer;
+    int rd_pos;
+    int wr_pos;
+    int buf_size;
+    int fd;
+    int type;
+};
+
+struct FILE *
+fopen(const char *file_name, int type)
+{
+  struct FILE* f = calloc(1, sizeof *f);
+  if (f == NULL){
+    return NULL;
+  }
+
+  f->rd_buffer = calloc(1, 512);
+  f->wr_buufer = calloc(1, 512);
+  if (f->rd_buffer == NULL || f->wr_buufer == NULL){
+    free(f->rd_buffer);
+    free(f->wr_buufer);
+    free(f);
+    return NULL;
+  }
+  f->buf_size = 512;
+  f->type = type;
+  f->fd = open(file_name);
+  return f;
+}
+
+void fclose(struct File*);
+int fread(void*, size_t, size_t, struct File*);
+int fwrite(void*, size_t, size_t, struct File*);

--- a/src/lib/user/stdsyscall.c
+++ b/src/lib/user/stdsyscall.c
@@ -73,6 +73,10 @@ fclose(struct FILE* f){
   fflush(f);
 
   close(f->fd);
+
+  free(f->rd_buffer);
+  free(f->wr_buufer);
+  free(f);
 }
 
 int

--- a/src/lib/user/stdsyscall.c
+++ b/src/lib/user/stdsyscall.c
@@ -33,6 +33,28 @@ fopen(const char *file_name, int type)
   return f;
 }
 
+struct FILE *
+fdopen(int fd, int type)
+{
+  struct FILE* f = calloc(1, sizeof *f);
+  if (f == NULL){
+    return NULL;
+  }
+
+  f->rd_buffer = calloc(1, 512);
+  f->wr_buufer = calloc(1, 512);
+  if (f->rd_buffer == NULL || f->wr_buufer == NULL){
+    free(f->rd_buffer);
+    free(f->wr_buufer);
+    free(f);
+    return NULL;
+  }
+  f->buf_size = 512;
+  f->type = type;
+  f->fd = fd;
+  return f;
+}
+
 void
 fclose(struct FILE* f){
   if (f == NULL){
@@ -84,7 +106,6 @@ fread(void* p, size_t a, size_t b, struct FILE* f)
     size -= f->rd_pos;
     read_bytes += read(f->fd, p + read_bytes, size);
     f->rd_pos = 0;
-    // f->rd_pos = 0;
     // while(size){
     //   if (!read(f->fd, f->rd_buffer, f->buf_size)){
     //     break;

--- a/src/lib/user/stdsyscall.c
+++ b/src/lib/user/stdsyscall.c
@@ -5,6 +5,7 @@ struct FILE{
     void* wr_buufer;
     int rd_pos;
     int wr_pos;
+    int old_pos;
     int buf_size;
     int fd;
     int type;
@@ -32,6 +33,135 @@ fopen(const char *file_name, int type)
   return f;
 }
 
-void fclose(struct File*);
-int fread(void*, size_t, size_t, struct File*);
-int fwrite(void*, size_t, size_t, struct File*);
+void
+fclose(struct FILE* f){
+  if (f == NULL){
+    return;
+  }
+  
+//   if (f->wr_pos){
+//     // /*If file position is different from buffer's write position
+//     //   it set fileposition to old position*/
+//     // if (tell(f->fd) != f->old_pos){
+//     //   seek(f->fd, f->old_pos);
+//     // }
+
+
+//   }
+  fflush(f);
+
+  close(f->fd);
+}
+
+int
+fread(void* p, size_t a, size_t b, struct FILE* f)
+{
+  if (f == NULL || f->type == WRONLY){
+    return -1;
+  }
+
+  size_t size = a * b;
+  if (size < a || size < b){
+    return -1;
+  }
+  
+  int read_bytes = 0;
+//   if (f->old_pos != tell(f->fd)){
+//     f->rd_pos = 0;
+//   }
+
+  if (size <= f->rd_pos){
+    for (int i = 0; i < size; i++){
+        p[i] = f->rd_buffer[i];
+        read_bytes++;
+    }
+    memmove(f->rd_buffer, f->rd_buffer + size, f->rd_pos - size);
+    f->rd_pos -= size;
+  }else{
+    for (int i = 0; i < f->rd_pos; i++){
+        p[read_bytes++] = f->rd_buffer[i];
+    }
+    size -= f->rd_pos;
+    read_bytes += read(f->fd, p + read_bytes, size);
+    f->rd_pos = 0;
+    // f->rd_pos = 0;
+    // while(size){
+    //   if (!read(f->fd, f->rd_buffer, f->buf_size)){
+    //     break;
+    //   }
+    //   if (size >= f->buf_size){
+    //     for(int i = 0; i < f->buf_size; i++){
+    //       p[read_bytes++] = f->rd_buffer[i];
+    //     }
+    //     size -= f->buf_size;
+    //   }else{
+    //     for(int i = 0; i < size; i++){
+    //       p[read_bytes++] = f->rd_buffer[i];
+    //     }
+    //     f->rd_pos = f->buf_size - size;
+    //     memmove(f->rd_buffer, f->rd_buffer + size, f->rd_pos);
+    //     size = 0;
+    //   }
+    // }
+  }
+
+//   if (read_bytes){
+//     f->old_pos = tell(f->fd);
+//   }
+
+  return read_bytes;
+}
+
+int
+fwrite(void* p, size_t a, size_t b, struct FILE* f)
+{
+  if (f == NULL || f->type == RDONLY){
+    return -1;
+  }
+
+  size_t size = a * b;
+  if (size < a || size < b){
+    return -1;
+  }
+
+  int write_bytes = 0;
+  if (size <= f->buf_size - f->wr_pos){
+    for(int i = 0; i < size; i++){
+      f->wr_buufer[f->wr_pos++] = p[write_bytes++];
+    }
+    if (f->buf_size == f->wr_pos){
+      fflush(f);
+    }
+  }else{
+    fflush(f);
+    write_bytes = write(f->fd, p, size);
+  }
+
+  return write_bytes;
+}
+
+void
+fseek(unsigned position, struct FILE *f)
+{
+  if (f == NULL){
+    return;
+  }
+
+  fflush(f);
+  f->rd_pos;
+  
+  seek(f->fd, position);
+}
+
+void
+fflush(struct FILE *f)
+{
+  if (f == NULL){
+    return;
+  }
+
+  if(f->wr_pos){
+    write(f->fd, f->wr_buufer, f->wr_pos);
+    f->wr_pos = 0;
+  }
+}

--- a/src/lib/user/stdsyscall.h
+++ b/src/lib/user/stdsyscall.h
@@ -1,0 +1,15 @@
+#include <syscall.h>
+#include <stddef.h>
+struct FILE;
+
+enum
+{
+  RDONLY,
+  WRONLY,
+  RDWR
+};
+
+struct FILE *fopen(const char *, int);
+void fclose(struct File*);
+int fread(void*, size_t, size_t, struct File*);
+int fwrite(void*, size_t, size_t, struct File*);

--- a/src/lib/user/stdsyscall.h
+++ b/src/lib/user/stdsyscall.h
@@ -10,6 +10,7 @@ enum
 };
 
 struct FILE *fopen(const char *, int);
+struct FILE *fdopen(const char *, int);
 void fclose(struct FILE *);
 int fread(void *, size_t, size_t, struct FILE *);
 int fwrite(void *, size_t, size_t, struct FILE *);

--- a/src/lib/user/stdsyscall.h
+++ b/src/lib/user/stdsyscall.h
@@ -10,7 +10,7 @@ enum
 };
 
 struct FILE *fopen(const char *, int);
-struct FILE *fdopen(const char *, int);
+struct FILE *fdopen(int, int);
 void fclose(struct FILE *);
 int fread(void *, size_t, size_t, struct FILE *);
 int fwrite(void *, size_t, size_t, struct FILE *);

--- a/src/lib/user/stdsyscall.h
+++ b/src/lib/user/stdsyscall.h
@@ -10,6 +10,8 @@ enum
 };
 
 struct FILE *fopen(const char *, int);
-void fclose(struct File*);
-int fread(void*, size_t, size_t, struct File*);
-int fwrite(void*, size_t, size_t, struct File*);
+void fclose(struct FILE *);
+int fread(void *, size_t, size_t, struct FILE *);
+int fwrite(void *, size_t, size_t, struct FILE *);
+void fseek(unsigned, struct FILE *);
+void fflush(struct FILE *);

--- a/src/threads/malloc.h
+++ b/src/threads/malloc.h
@@ -5,9 +5,16 @@
 #include <stddef.h>
 
 void malloc_init (void);
+
+/*Kernel malloc*/
 void *malloc (size_t) __attribute__ ((malloc));
 void *calloc (size_t, size_t) __attribute__ ((malloc));
 void *realloc (void *, size_t);
+
+/*User malloc*/
+void *user_malloc (size_t) __attribute__ ((malloc));
+void *user_realloc (void *, size_t);
+
 void free (void *);
 
 #endif /* threads/malloc.h */

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -584,40 +584,6 @@ allocate_tid (void)
   return tid;
 }
 
-int 
-allocate_fd(struct file* file)
-{
-  struct thread *cur = thread_current ();
-
-  for (int fd = 3; fd < 128; fd++){
-    if (cur->fd_table[fd] == NULL){
-      cur->fd_table[fd] = file;
-      return fd;
-    }
-  }
-
-  return -1;
-}
-
-void
-free_fd(int fd)
-{
-  struct thread *cur = thread_current ();
-
-  cur->fd_table[fd] = NULL;
-}
-
-struct file*
-get_file(int fd){
-  struct thread *cur = thread_current ();
-
-  if(fd >= 128 || fd < 0){
-    return NULL;
-  }
-
-  return cur->fd_table[fd];
-}
-
 /*Function for call schedule from other source code*/
 void
 __schedule()

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -90,6 +90,7 @@ thread_init (void)
   ASSERT (intr_get_level () == INTR_OFF);
 
   lock_init (&tid_lock);
+  lock_init (&stdin_lock);
   list_init (&ready_list);
   list_init (&all_list);
 

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -106,11 +106,10 @@ struct thread
     struct semaphore sema;              /*For parents that wait child process*/
     struct file* executable;            /*Pointer for executable file that is about this process*/
     int exit_status;                    /*Status for parents*/
+//  struct file** fd_table;         /*File descriptor table*/
+    struct file** fd_table;
 #endif
 
-#ifdef FILESYS
-    struct file* fd_table[128];         /*File descriptor table*/
-#endif
     /* Owned by thread.c. */
     unsigned magic;                     /* Detects stack overflow. */
   };
@@ -150,10 +149,6 @@ int thread_get_nice (void);
 void thread_set_nice (int);
 int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
-
-int allocate_fd(struct file*);
-void free_fd(int);
-struct file* get_file(int);
 
 void __schedule();
 

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -114,6 +114,7 @@ struct thread
     unsigned magic;                     /* Detects stack overflow. */
   };
 
+struct lock stdin_lock;
 /* If false (default), use round-robin scheduler.
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -21,7 +21,7 @@
 
 /*File descriptor table size and max size*/
 #define FD_LIMIT 1024 //지금은 매크로지만 변수로 하는 것도 좋아보임(필요에 따라 최대 크기를 늘릴 수 있게)
-int fd_size = 128;
+static int fd_size = 128;
 
 static thread_func start_process NO_RETURN;
 static bool load (const char *cmdline, void (**eip) (void), void **esp);

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -629,13 +629,13 @@ allocate_fd(struct file* file)
   }
   
   if (fd_size < FD_LIMIT){
-    struct file** tmp = cur->fd_table;
-    cur->fd_table = calloc(fd_size*2, sizeof *cur->fd_table);
-    for (int i = 0; i < fd_size; i++){
-      cur->fd_table[i] = tmp[i];
-    }
-    free(tmp);
-
+    // struct file** tmp = cur->fd_table;
+    // cur->fd_table = calloc(fd_size*2, sizeof *cur->fd_table);
+    // for (int i = 0; i < fd_size; i++){
+    //   cur->fd_table[i] = tmp[i];
+    // }
+    // free(tmp);
+    cur->fd_table = realloc(cur->fd_table, fd_size * sizeof *cur->fd_table * 2);
     int fd = fd_size;
     fd_size *= 2;
     cur->fd_table[fd] = file;

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -8,4 +8,8 @@ int process_wait (tid_t);
 void process_exit (void);
 void process_activate (void);
 
+/*About file and file discriptor*/
+int allocate_fd(struct file*);
+void free_fd(int);
+struct file* get_file(int);
 #endif /* userprog/process.h */

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -320,17 +320,25 @@ syscall_handler (struct intr_frame *f)
     }
 
     case SYS_MALLOC:{
-      size_t size = *(int*)(f->esp + 4);
+      if (!validate_esp(f->esp + 4, 1)){
+        __exit(-1);
+      }
+
+      size_t size = *(size_t *)(f->esp + 4);
       f->eax = user_malloc(size);
       break;
     }
 
     case SYS_FREE:{
+      if (!validate_esp(f->esp + 4, 1)){
+        __exit(-1);
+      }
+
       void *p = *(void**)(f->esp + 4);
       if(!validate_buffer(p, 1)){
         __exit(-1);
       }
-      
+
       free(p);
       break;
     }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -4,6 +4,7 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/vaddr.h"
+#include "threads/malloc.h"
 #include "lib/user/syscall.h"
 #include "filesys/file.h"
 #include "filesys/filesys.h"
@@ -315,6 +316,22 @@ syscall_handler (struct intr_frame *f)
       }
       
       f->eax = filesys_remove(file_name);
+      break;
+    }
+
+    case SYS_MALLOC:{
+      size_t size = *(int*)(f->esp + 4);
+      f->eax = user_malloc(size);
+      break;
+    }
+
+    case SYS_FREE:{
+      void *p = *(void**)(f->esp + 4);
+      if(!validate_buffer(p, 1)){
+        __exit(-1);
+      }
+      
+      free(p);
       break;
     }
   }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -171,10 +171,10 @@ syscall_handler (struct intr_frame *f)
         __exit(-1);
       }
 
-      if (fd < 0 || fd >= 128){
-        f->eax = -1;
-        break;
-      }
+      // if (fd < 0 || fd >= 128){
+      //   f->eax = -1;
+      //   break;
+      // }
 
       if(fd == STDIN_FILENO){
         unsigned bytes_read = 0;
@@ -211,10 +211,10 @@ syscall_handler (struct intr_frame *f)
         __exit(-1);
       }
 
-      if (fd < 0 || fd >= 128){
-        f->eax = -1;
-        break;
-      }
+      // if (fd < 0 || fd >= 128){
+      //   f->eax = -1;
+      //   break;
+      // }
 
       if(fd == STDOUT_FILENO){
         putbuf(buffer,size);

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -94,6 +94,7 @@ syscall_handler (struct intr_frame *f)
       NOT_REACHED();
       break;
     }
+    
     case SYS_EXIT:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -103,6 +104,7 @@ syscall_handler (struct intr_frame *f)
       __exit(status);
       break;
     }
+
     case SYS_EXEC:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -116,6 +118,7 @@ syscall_handler (struct intr_frame *f)
       f->eax = process_execute(file_name);
       break;
     }
+
     case SYS_WAIT:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -126,6 +129,7 @@ syscall_handler (struct intr_frame *f)
       // printf("f->eax : %d\n",f->eax);
       break;
     }
+
     case SYS_CREATE:{
       if (!validate_esp(f->esp + 4, 2)){
         __exit(-1);
@@ -140,6 +144,7 @@ syscall_handler (struct intr_frame *f)
       f->eax = filesys_create(file_name, size);
       break;
     }
+
     case SYS_OPEN:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -159,6 +164,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_READ:{
       if (!validate_esp(f->esp + 4, 3)){
         __exit(-1);
@@ -199,6 +205,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_WRITE:{
       if (!validate_esp(f->esp + 4, 3)){
         __exit(-1);
@@ -230,6 +237,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_SEEK:{
       if (!validate_esp(f->esp + 4, 2)){
         __exit(-1);
@@ -243,6 +251,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_CLOSE:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -256,6 +265,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_FILESIZE:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -270,6 +280,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_TELL:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);
@@ -285,6 +296,7 @@ syscall_handler (struct intr_frame *f)
       }
       break;
     }
+
     case SYS_REMOVE:{
       if (!validate_esp(f->esp + 4, 1)){
         __exit(-1);

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -240,7 +240,6 @@ syscall_handler (struct intr_frame *f)
           }else{
             f->eax = -1;
           }
-         
         }
       }
       break;


### PR DESCRIPTION
1. fd테이블을 포인터 멤버변수로 TCB에 등록, 테이블 크기를 동적으로 조정 가능하게 변경
2. 표준입력은 한글자 입력만을 원자적으로 보장하기 때문에 표준입력 시스템콜 핸들러에서 세마포어를 이용한 동기화 추가
3. inode구조체에 세마포어 멤버를 추가하여 파일에 대한 read, write이 원자적으로 실핼될 수 있도록 구현
4. 기존 malloc함수는 커널영역 함수기 때문에 malloc, free 시스템콜을 추가해 유저영역에서 메모리 동적할당 기능 추가
5. C표준 파일입출력 함수 fopen, fclose, fread, fwrite 등을 구현

realloc이라는 함수는 시스템콜로 등록여부를 못정해서 threads/malloc.c에 유저영역의 할당 함수만 추가함, 시스템콜 등록은 아직 x