### PR TITLE
feat: kill exit_status값 설정, rox write 처리 변경

### DIFF
--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -89,6 +89,7 @@ kill (struct intr_frame *f)
       printf ("%s: dying due to interrupt %#04x (%s).\n",
               thread_name (), f->vec_no, intr_name (f->vec_no));
       intr_dump_frame (f);
+      thread_current()->exit_status = -1;
       thread_exit (); 
 
     case SEL_KCSEG:
@@ -104,6 +105,7 @@ kill (struct intr_frame *f)
          kernel. */
       printf ("Interrupt %#04x (%s) in unknown segment %04x\n",
              f->vec_no, intr_name (f->vec_no), f->cs);
+      thread_current()->exit_status = -1;
       thread_exit ();
     }
 }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -226,11 +226,7 @@ syscall_handler (struct intr_frame *f)
           f->eax = -1;
         }else{
           int bytes_written = file_write(file,buffer,size);
-          if (bytes_written){
-            f->eax = bytes_written;
-          }else{
-            f->eax = -1;
-          }
+          f->eax = bytes_written;
         }
       }
       break;


### PR DESCRIPTION
1. kill함수 내에서 thread_exit 전에 eixt_status를 -1로 설정
2. rox write 처리코드를 기존으로 변경